### PR TITLE
Bump Bugsnag dep to 4.1.3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,7 @@
 buildscript {
   repositories {
     mavenCentral()
+    maven { url 'https://maven.google.com/' }
   }
 
   dependencies {
@@ -40,7 +41,7 @@ dependencies {
 
   provided 'com.segment.analytics.android:analytics:4.0.0'
 
-  compile 'com.bugsnag:bugsnag-android:3.2.6'
+  compile 'com.bugsnag:bugsnag-android:4.1.3'
 
   testCompile 'junit:junit:4.12'
   testCompile('org.robolectric:robolectric:3.0') {
@@ -57,3 +58,7 @@ dependencies {
 
 apply from: rootProject.file('gradle/attach-jar.gradle')
 apply from: rootProject.file('gradle/gradle-mvn-push.gradle')
+
+repositories {
+  maven { url 'https://maven.google.com/' }
+}


### PR DESCRIPTION
- Updates Bugsnag dep to 4.1.3
- No Android IDE errors as a result of the bump
- All unit tests pass
- CircleCI passes